### PR TITLE
Iterator with next function

### DIFF
--- a/src/darray.c
+++ b/src/darray.c
@@ -80,3 +80,19 @@ void kitc_darray_clear(kitc_darray *d) {
 }
 
 size_t kitc_darray_len(kitc_darray *d) { return d->len; }
+
+kitc_darray_iter kitc_darray_iter_new(kitc_darray *d) {
+  kitc_darray_iter iterator;
+  iterator.array = d;
+  iterator.current_idx = 0;
+  return iterator;
+}
+
+void* kitc_darray_iter_next(kitc_darray_iter *iterator) {
+  if (iterator->current_idx < iterator->array->len) {
+    size_t stride = iterator->array->type_size;
+    return &iterator->array->data[(stride * iterator->current_idx++)]; // postincrement current_idx
+  } else {
+    return NULL;
+  }
+}

--- a/src/darray.h
+++ b/src/darray.h
@@ -60,11 +60,26 @@ void kitc_darray_clear(kitc_darray *d);
 */
 size_t kitc_darray_len(kitc_darray *d);
 
-/* TODO
- *
- * Public API
- *
- *
- */
+/**
+  @brief an iterator that can be used to iterate through the array more easily
+          than using for loops with variables
+*/
+typedef struct kitc_darray_iter {
+  kitc_darray *array;
+  size_t current_idx;
+} kitc_darray_iter;
+
+/**
+ * @brief creates a support iterator struct
+ * @returns the iterator struct. pass this to `kitc_darray_iter_next`
+*/
+kitc_darray_iter kitc_darray_iter_new(kitc_darray *d);
+
+/**
+ * @returns a pointer to the next element in the array or NULL if you're at the end
+*/
+void* kitc_darray_iter_next(kitc_darray_iter *iterator);
+
+// TODO: decide more functions for public API
 
 #endif // KITC_DARRAY_H

--- a/tests/test_darray.c
+++ b/tests/test_darray.c
@@ -3,6 +3,7 @@
 #include "../src/darray.h"
 
 int main() {
+  // Basic push example
   kitc_darray *d = kitc_darray_new(sizeof(double), 11);
   double value = 64.0;
   for (int i = 0; i < 10; i++) {
@@ -14,6 +15,7 @@ int main() {
   double inserted_value = 11111111.0;
   kitc_darray_ins(d, &inserted_value, 4);
 
+  // Demonstrate pulling data out with an explicit cast and popping elements
   for (int i = d->len - 1; i >= 0; i--) {
     double value;
     kitc_darray_pop(d, &value);
@@ -21,6 +23,23 @@ int main() {
   }
 
   assert(d->len == 0);
+
+  // Iterator example
+  // ================
+  
+  // push some values back in
+  double new_value = 1.0;
+  for (int i = 0; i < 10; i++) {
+    kitc_darray_push(d, &new_value);
+    new_value++;
+  }
+
+  // create iterator and print out all values
+  kitc_darray_iter double_iter = kitc_darray_iter_new(d);
+  double *current;
+  while ((current = kitc_darray_iter_next(&double_iter))) {
+    printf("value %.2f\n", *current);
+  }
 
   return 0;
 }


### PR DESCRIPTION
makes it a bit cleaner to iterate through items instead of having to do something like
`m.material = ((bh_material *)materials->data)[j];` to cast and get the right index out.